### PR TITLE
Alterando biblioteca para enviar idempotency key no header

### DIFF
--- a/src/MercadoPago/Http/HttpMethod.php
+++ b/src/MercadoPago/Http/HttpMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MercadoPago\Http;
+
+class HttpMethod
+{
+    public const GET = "GET";
+    public const POST = "POST";
+    public const PUT = "PUT";
+    public const PATCH = "PATCH";
+    public const DELETE = "DELETE";
+
+}

--- a/src/MercadoPago/Manager.php
+++ b/src/MercadoPago/Manager.php
@@ -1,5 +1,7 @@
 <?php
 namespace MercadoPago;
+use MercadoPago\Http\HttpMethod;
+
 /**
  * Class Manager
  *
@@ -434,8 +436,8 @@ class Manager
 
     private function shouldAddIdempotencyKey(string $method): bool
     {
-        $method = strtolower($method);
-        $methodShouldHaveIdempotencyKey = ["post", "put", "patch"];
+        $method = strtoupper($method);
+        $methodShouldHaveIdempotencyKey = [HttpMethod::POST, HttpMethod::PUT, HttpMethod::PATCH];
         return in_array($method, $methodShouldHaveIdempotencyKey);
     }
 

--- a/src/MercadoPago/Manager.php
+++ b/src/MercadoPago/Manager.php
@@ -84,7 +84,7 @@ class Manager
 
         $this->_setDefaultHeaders($configuration->query);
         $this->_setCustomHeaders($entity, $configuration->query);
-        //$this->_setIdempotencyHeader($configuration->query, $configuration, $method);
+        $this->_setIdempotencyHeader($configuration->query, $configuration, $method);
         $this->setQueryParams($entity);
         
         return $this->_client->{$method}($configuration->url, $configuration->query);
@@ -411,15 +411,8 @@ class Manager
      */
     protected function _setIdempotencyHeader(&$query, $configuration, $method)
     {
-        if (!isset($configuration->methods[$method])) {
-            return;
-        }
-        $fields = '';
-        if ($configuration->methods[$method]['idempotency']) {
-            $fields = $this->_getIdempotencyAttributes($configuration->attributes);
-        }
-        if ($fields != '') {
-            $query['headers']['x-idempotency-key'] = hash(self::$CIPHER, $fields);
+        if ($this->shouldAddIdempotencyKey($method) && !$this->headerExists($query['headers'], 'X-Idempotency-Key')) {
+            $query['headers']['x-idempotency-key'] = $this->generateUUID();
         }
     }
     /**
@@ -436,5 +429,50 @@ class Manager
             }
         }
         return implode('&', $result);
+    }
+
+
+    private function shouldAddIdempotencyKey(string $method): bool
+    {
+        $method = strtolower($method);
+        $methodShouldHaveIdempotencyKey = ["post", "put", "patch"];
+        return in_array($method, $methodShouldHaveIdempotencyKey);
+    }
+
+    private function headerExists(array $headers, string $header): bool
+    {
+        foreach($headers as $h) {
+            if (strtolower($h) == strtolower($header)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function generateUUID()
+    {
+        return sprintf(
+            '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+            // 32 bits for "time_low"
+            mt_rand(0, 0xffff),
+            mt_rand(0, 0xffff),
+
+            // 16 bits for "time_mid"
+            mt_rand(0, 0xffff),
+
+            // 16 bits for "time_hi_and_version",
+            // four most significant bits holds version number 4
+            mt_rand(0, 0x0fff) | 0x4000,
+
+            // 16 bits, 8 bits for "clk_seq_hi_res",
+            // 8 bits for "clk_seq_low",
+            // two most significant bits holds zero and one for variant DCE1.1
+            mt_rand(0, 0x3fff) | 0x8000,
+
+            // 48 bits for "node"
+            mt_rand(0, 0xffff),
+            mt_rand(0, 0xffff),
+            mt_rand(0, 0xffff)
+        );
     }
 }


### PR DESCRIPTION
## Mudanças feitas:
 * Alterando para permitir enviar o idempotency key no header da requisição .

## Mudanças Gerais
 * Criadas funções na classe Manager.php para que seja possível saber se deve ou não adicionar idempotency key no header da requisição
 * Criada função de geração de UUID
 * Criada função de verificação se existe uma chave no header da requisição
 * Alterada função de setar idempotency key no array de headers

## Problema Resolvido
 * Ao olhar a documentação da api do mercado pago puder notar que é obrigatorio enviar o idempotency key no header da requisição, para integrações criadas apartir de 01/11/2023, e nessa versão não tinha suporte para o envio da chave no header sendo assim não era possivel criar transação.
 
## PR validation checklist:

- [x] Title and clear description of the PR
- [ ] Tests of my functionality
- [ ] Documentation of my functionality
- [ ] Tests executed and passed
- [ ] Branch Coverage >= 80%
